### PR TITLE
Complete the CustomPropBuilder implementation

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -16,5 +16,12 @@ if [ "$STASHED" -eq 0 ]; then
   git stash pop -q
 fi
 
-# return the './gradlew spotlessCheck' exit code
+if [ "$RESULT" -ne 0 ]; then
+  echo
+  echo "If you are seeing spotless failures, run:"
+  echo "./gradlew spotlessApply"
+  echo
+fi
+
+# return the './gradlew check' exit code
 exit $RESULT

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -5,20 +5,14 @@ echo "==> Running the pre-commit git hook..."
 
 # stash any unstaged changes
 git stash --keep-index --include-untracked | grep -vi "No local changes to save"
-stashed=$?
+STASHED=$?
 
-# format and add any modifications
-./gradlew spotlessApply --daemon
-git add .
-
-# run the spotlessCheck with the gradle wrapper
-./gradlew spotlessCheck --daemon
-
-# store the last exit code in a variable
+# run all checks before committing
+./gradlew check --daemon
 RESULT=$?
 
-# unstash the unstashed changes
-if [ "$stashed" -eq 0 ]; then
+# unstash any stashed changes
+if [ "$STASHED" -eq 0 ]; then
   git stash pop -q
 fi
 

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -5,16 +5,16 @@ echo "==> Running the pre-push git hook..."
 
 # stash any unstaged changes
 git stash --keep-index --include-untracked | grep -vi "No local changes to save"
-stashed=$?
+STASHED=$?
 
 # run tests with the gradle wrapper
-./gradlew check test --daemon
+./gradlew test --daemon
 
 # store the last exit code in a variable
 RESULT=$?
 
 # unstash the unstashed changes
-if [ "$stashed" -eq 0 ]; then
+if [ "$STASHED" -eq 0 ]; then
   git stash pop -q
 fi
 

--- a/.idea/watcherTasks.xml
+++ b/.idea/watcherTasks.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectTasksOptions">
+    <TaskOptions isEnabled="true">
+      <option name="arguments" value="spotlessApply" />
+      <option name="checkSyntaxErrors" value="true" />
+      <option name="description" />
+      <option name="exitCodeBehavior" value="ERROR" />
+      <option name="fileExtension" value="java" />
+      <option name="immediateSync" value="true" />
+      <option name="name" value="Spotless" />
+      <option name="output" value="" />
+      <option name="outputFilters">
+        <array />
+      </option>
+      <option name="outputFromStdout" value="false" />
+      <option name="program" value="$ProjectFileDir$/gradlew" />
+      <option name="runOnExternalChanges" value="true" />
+      <option name="scopeName" value="Project Files" />
+      <option name="trackOnlyRoot" value="false" />
+      <option name="workingDir" value="$ProjectFileDir$" />
+      <envs />
+    </TaskOptions>
+  </component>
+</project>

--- a/props-core/src/main/java/sh/props/CustomProp.java
+++ b/props-core/src/main/java/sh/props/CustomProp.java
@@ -30,6 +30,7 @@ import static java.util.Objects.isNull;
 
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 import sh.props.annotations.Nullable;
 import sh.props.converter.Converter;
 import sh.props.exceptions.InvalidReadOpException;
@@ -91,7 +92,9 @@ public abstract class CustomProp<T> extends AbstractProp<T> implements Converter
   /**
    * Validates any updates to a property's value.
    *
-   * <p>This method can be overridden for more advanced validation requirements.
+   * <p>This method can be overridden for more advanced validation requirements. If you override
+   * this method, please be aware that any exceptions thrown by this method will only be observed by
+   * error consumers, registered to the prop object with {@link #subscribe(Consumer, Consumer)}.
    *
    * @param value the value to validate
    * @throws InvalidUpdateOpException when the validation fails

--- a/props-core/src/main/java/sh/props/CustomPropBuilder.java
+++ b/props-core/src/main/java/sh/props/CustomPropBuilder.java
@@ -34,55 +34,53 @@ import sh.props.converter.Converter;
  * @param <T> the type of the prop
  */
 public class CustomPropBuilder<T> {
+
+  private final Registry registry;
+  private final Converter<T> converter;
   @Nullable String description;
   @Nullable private T defaultValue;
   private boolean isRequired;
   private boolean isSecret;
 
   /**
-   * Creates a new {@link CustomProp} based on the provided arguments. If any <code>registries
-   * </code> are specified, the resulting Prop will be bound
+   * Default constructor.
    *
-   * @param key the Prop's key; this parameter is required and cannot be null
+   * @param registry the registry to which the created object will be bound
    * @param converter the type converter that can serialize/deserialize the Prop's value
-   * @param registries if any registries that the Prop will be bound to.
-   * @return an initialized Prop object
    */
-  public CustomProp<T> build(String key, Converter<T> converter, Registry... registries) {
-    CustomProp<T> prop = this.build(key, converter);
-    if (registries == null) {
-      throw new IllegalArgumentException("You must pass at least one non-null registry");
+  public CustomPropBuilder(Registry registry, Converter<T> converter) {
+    if (registry == null) {
+      throw new IllegalArgumentException("The registry cannot be null");
     }
+    this.registry = registry;
 
-    // bind the prop to all the specified registries
-    for (Registry registry : registries) {
-      registry.bind(prop);
+    if (converter == null) {
+      throw new IllegalArgumentException("The converter cannot be null");
     }
-    return prop;
+    this.converter = converter;
   }
 
   /**
    * Creates a new {@link CustomProp} based on the provided arguments.
    *
    * @param key the Prop's key; this parameter is required and cannot be null
-   * @param converter the type converter that can serialize/deserialize the Prop's value
    * @return an initialized Prop object
    */
-  public CustomProp<T> build(String key, Converter<T> converter) {
-    return new CustomProp<>(
-        key, this.defaultValue, this.description, this.isRequired, this.isSecret) {
-      @Override
-      @Nullable
-      public T decode(String value) {
-        return converter.decode(value);
-      }
+  public CustomProp<T> build(String key) {
+    return this.registry.bind(
+        new CustomProp<>(key, this.defaultValue, this.description, this.isRequired, this.isSecret) {
+          @Override
+          @Nullable
+          public T decode(String value) {
+            return CustomPropBuilder.this.converter.decode(value);
+          }
 
-      @Override
-      @Nullable
-      public String encode(@Nullable T value) {
-        return converter.encode(value);
-      }
-    };
+          @Override
+          @Nullable
+          public String encode(@Nullable T value) {
+            return CustomPropBuilder.this.converter.encode(value);
+          }
+        });
   }
 
   /**
@@ -91,8 +89,9 @@ public class CustomPropBuilder<T> {
    *
    * @param defaultValue this Prop's default value
    */
-  public void defaultValue(T defaultValue) {
+  public CustomPropBuilder<T> defaultValue(T defaultValue) {
     this.defaultValue = defaultValue;
+    return this;
   }
 
   /**
@@ -101,8 +100,9 @@ public class CustomPropBuilder<T> {
    *
    * @param required true if the Prop must have a value, false if having a value is optional
    */
-  public void required(boolean required) {
+  public CustomPropBuilder<T> required(boolean required) {
     this.isRequired = required;
+    return this;
   }
 
   /**
@@ -110,8 +110,9 @@ public class CustomPropBuilder<T> {
    *
    * @param secret true if the Prop represents a secret
    */
-  public void secret(boolean secret) {
+  public CustomPropBuilder<T> secret(boolean secret) {
     this.isSecret = secret;
+    return this;
   }
 
   /**
@@ -120,7 +121,8 @@ public class CustomPropBuilder<T> {
    *
    * @param description the Prop's description
    */
-  public void description(String description) {
+  public CustomPropBuilder<T> description(String description) {
     this.description = description;
+    return this;
   }
 }

--- a/props-core/src/main/java/sh/props/Registry.java
+++ b/props-core/src/main/java/sh/props/Registry.java
@@ -81,6 +81,10 @@ public class Registry implements Notifiable {
    * Keep the implementation performant by reducing the number of Prop objects registered for the
    * same key!
    *
+   * <p>NOTE 2: There is nothing stopping a caller from binding the same Prop object to multiple
+   * Registries. This is an experimental and untested feature that may be developed in the future,
+   * or depending on feedback might be disallowed. Mileage may vary, use at your own risk! ;)
+   *
    * @param prop the prop object to bind
    * @param <T> the prop's type
    * @param <PropT> the class of the {@link Prop} with its upper bound ({@link AbstractProp})
@@ -117,12 +121,28 @@ public class Registry implements Notifiable {
   }
 
   /**
-   * Retrieves the value for the specified key.
+   * Convenience method that retrieves the string representation of the value associated with the
+   * given key. If the underlying value is not actually a {@link String}, this method will
+   * effectively call {@link Converter#encode(Object)}, which by default is implemented as {@link
+   * Object#toString()}.
+   *
+   * @param key the key to retrieve
+   * @return the effective value, or <code>null</code> if not found
+   */
+  @Nullable
+  public String get(String key) {
+    return this.get(key, Cast.asString());
+  }
+
+  /**
+   * Convenience method that retrieves the value associated with the given key.
    *
    * <p>Since this method retrieves the value directly from the underlying {@link Datastore}, it is
-   * the fastest way to observe a changed value. Any bound {@link Prop} objects will have to wait
-   * for {@link Registry#sendUpdate(String, String, Layer)} to finish executing asynchronously
-   * before observing any changes.
+   * the fastest way to observe a changed value.
+   *
+   * <p>It differs from any bound {@link Prop} objects in that they will have to wait for {@link
+   * Registry#sendUpdate(String, String, Layer)} to asynchronously finish executing before observing
+   * any changes.
    *
    * @param key the key to retrieve
    * @param converter the type converter used to cast the value to its appropriate type
@@ -145,20 +165,14 @@ public class Registry implements Notifiable {
   }
 
   /**
-   * Convenience method that retrieves the serialized value for the specified key.
+   * Initializes a {@link CustomPropBuilder} which can be used to initialize custom Props, without
+   * the user needing to extend {@link CustomProp}.
    *
-   * <p>This method is mostly useful in the following two cases:
-   *
-   * <ul>
-   *   <li>- the property represented by the specified key is a <code>String</code>
-   *   <li>- the calling code wants to deserialize the value using a different mechanism
-   * </ul>
-   *
-   * @param key the key to retrieve
-   * @return the effective value, or <code>null</code> if not found
+   * @param converter the type converter used to cast the created custom Props
+   * @param <T> the type of the Props that will be built by the returned builder
+   * @return a builder object
    */
-  @Nullable
-  public String get(String key) {
-    return this.get(key, Cast.asString());
+  public <T> CustomPropBuilder<T> builder(Converter<T> converter) {
+    return new CustomPropBuilder<>(this, converter);
   }
 }

--- a/props-core/src/test/java/sh/props/CustomPropTest.java
+++ b/props-core/src/test/java/sh/props/CustomPropTest.java
@@ -1,0 +1,117 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2021 Mihai Bojin
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+package sh.props;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.core.StringContains.containsString;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static sh.props.source.impl.InMemory.UPDATE_REGISTRY_ON_EVERY_WRITE;
+
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+import sh.props.converter.Cast;
+import sh.props.exceptions.InvalidReadOpException;
+import sh.props.exceptions.InvalidUpdateOpException;
+import sh.props.source.impl.InMemory;
+import sh.props.testhelpers.TestErrorOnSetProp;
+
+@SuppressWarnings("NullAway")
+class CustomPropTest {
+
+  @Test
+  void secretProp() {
+    // ARRANGE
+    InMemory source = new InMemory(UPDATE_REGISTRY_ON_EVERY_WRITE);
+
+    Registry registry = new RegistryBuilder(source).build();
+
+    var prop =
+        new CustomPropBuilder<>(registry, Cast.asString())
+            .defaultValue("A_SECRET")
+            .secret(true)
+            .build("key");
+
+    // ACT / ASSERT
+    assertThat(prop.get(), equalTo("A_SECRET"));
+    assertThat(prop.toString(), not(containsString("A_SECRET")));
+  }
+
+  @Test
+  void propWithDescription() {
+    // ARRANGE
+    InMemory source = new InMemory(UPDATE_REGISTRY_ON_EVERY_WRITE);
+
+    Registry registry = new RegistryBuilder(source).build();
+
+    var prop =
+        new CustomPropBuilder<>(registry, Cast.asString())
+            .description("a_description")
+            .build("key");
+
+    // ACT / ASSERT
+    assertThat(prop.description(), equalTo("a_description"));
+  }
+
+  @Test
+  void requiredProp() {
+    // ARRANGE
+    InMemory source = new InMemory(UPDATE_REGISTRY_ON_EVERY_WRITE);
+
+    Registry registry = new RegistryBuilder(source).build();
+
+    var prop = new CustomPropBuilder<>(registry, Cast.asString()).required(true).build("key");
+
+    // ACT / ASSERT
+    assertThrows(InvalidReadOpException.class, prop::get);
+
+    source.put("key", "value");
+    await().until(prop::get, equalTo("value"));
+  }
+
+  @Test
+  void setError() {
+
+    // ARRANGE
+    InMemory source = new InMemory(UPDATE_REGISTRY_ON_EVERY_WRITE);
+
+    Registry registry = new RegistryBuilder(source).build();
+
+    AtomicReference<Throwable> capture = new AtomicReference<>();
+
+    var prop = registry.bind(new TestErrorOnSetProp("key", 0));
+    prop.subscribe((ignore) -> {}, capture::set);
+
+    // ACT / ASSERT
+    assertThat(prop.get(), equalTo(0));
+
+    source.put("key", "2");
+    await().until(capture::get, instanceOf(InvalidUpdateOpException.class));
+  }
+}

--- a/props-core/src/test/java/sh/props/RegistryTest.java
+++ b/props-core/src/test/java/sh/props/RegistryTest.java
@@ -193,4 +193,20 @@ class RegistryTest extends AwaitAssertionTest {
     await().until(localValue1::get, equalTo(2));
     await().until(localValue2::get, equalTo(2));
   }
+
+  @Test
+  void customPropCreatedWithBuilder() {
+    // ARRANGE
+    InMemory source = new InMemory(UPDATE_REGISTRY_ON_EVERY_WRITE);
+
+    Registry registry = new RegistryBuilder(source).build();
+
+    var prop = registry.builder(Cast.asInteger()).defaultValue(1).build("key");
+
+    // ACT / ASSERT
+    assertThat(prop.get(), equalTo(1));
+
+    source.put("key", "2");
+    await().until(prop::get, equalTo(2));
+  }
 }

--- a/props-core/src/test/java/sh/props/testhelpers/TestErrorOnSetProp.java
+++ b/props-core/src/test/java/sh/props/testhelpers/TestErrorOnSetProp.java
@@ -1,0 +1,44 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2021 Mihai Bojin
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+package sh.props.testhelpers;
+
+import sh.props.annotations.Nullable;
+import sh.props.exceptions.InvalidUpdateOpException;
+import sh.props.typed.IntegerProp;
+
+public class TestErrorOnSetProp extends IntegerProp {
+
+  public TestErrorOnSetProp(String key, @Nullable Integer defaultValue) {
+    super(key, defaultValue, null, false, false);
+  }
+
+  @Override
+  protected void validateBeforeSet(@Nullable Integer value) throws InvalidUpdateOpException {
+    if (value != null && value > 1) {
+      throw new InvalidUpdateOpException("invalid value");
+    }
+  }
+}


### PR DESCRIPTION
# What
- convenience method in Registry (`.builder()`)
- testing all CustomProp features
- closes #40

# Drive-by:
- no longer runs spotlessApply on pre-commit, avoiding a series of conflicts caused by unstashing unformatted code on top of recently formatted code
- moved to IntelliJ's `File Watcher` plugin and disabled `Save Actions`