### PR TITLE
OnDemandSource implementation for AWS SecretsManager

### DIFF
--- a/props-aws/src/intTest/java/sh/props/aws/AwsSecretsManagerIntTest.java
+++ b/props-aws/src/intTest/java/sh/props/aws/AwsSecretsManagerIntTest.java
@@ -34,7 +34,10 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
-import static sh.props.aws.AwsSecretsManager.getSecretValue;
+import static sh.props.aws.AwsHelpers.buildClient;
+import static sh.props.aws.AwsHelpers.defaultClientConfiguration;
+import static sh.props.aws.AwsHelpers.getSecretValue;
+import static sh.props.aws.AwsHelpers.listSecrets;
 
 import java.time.Duration;
 import java.util.UUID;
@@ -63,7 +66,7 @@ class AwsSecretsManagerIntTest {
   @BeforeAll
   static void beforeAll() {
     // initialize the client
-    client = AwsSecretsManager.buildClient(AwsSecretsManager.defaultClientConfiguration(), null);
+    client = buildClient(defaultClientConfiguration(), null);
 
     // create secrets for the test env.
     var key1 = CreateSecretRequest.builder().name(secret1).secretString(SECRET_VALUE).build();
@@ -83,7 +86,7 @@ class AwsSecretsManagerIntTest {
     await()
         .pollDelay(Duration.ZERO)
         .until(() -> getSecretValue(client, secret2).join().secretString(), notNullValue());
-    await().until(() -> AwsSecretsManager.listSecrets(client), hasSize(equalTo(2)));
+    await().until(() -> listSecrets(client), hasSize(equalTo(2)));
   }
 
   @AfterAll
@@ -104,7 +107,7 @@ class AwsSecretsManagerIntTest {
   @Timeout(value = 5)
   void secretsCanBeRetrievedFromSecretsManager() {
     // ARRANGE
-    var secretsManager = new AwsSecretsManager();
+    var secretsManager = new AwsSecretsManagerOnDemand();
     var registry = new RegistryBuilder(secretsManager).build();
 
     var invalidKey = "someInvalidSecretName" + UUID.randomUUID();

--- a/props-aws/src/intTest/java/sh/props/aws/AwsSecretsManagerIntTest.java
+++ b/props-aws/src/intTest/java/sh/props/aws/AwsSecretsManagerIntTest.java
@@ -107,7 +107,7 @@ class AwsSecretsManagerIntTest {
   @Timeout(value = 5)
   void secretsCanBeRetrievedFromSecretsManager() {
     // ARRANGE
-    var secretsManager = new AwsSecretsManagerOnDemand();
+    var secretsManager = new AwsSecretsManager();
     var registry = new RegistryBuilder(secretsManager).build();
 
     var invalidKey = "someInvalidSecretName" + UUID.randomUUID();
@@ -134,7 +134,7 @@ class AwsSecretsManagerIntTest {
   @Timeout(value = 5)
   void loadSecretsOnDemand() {
     // ARRANGE
-    var secretsManager = new AwsSecretsManager();
+    var secretsManager = new AwsSecretsManagerOnDemand();
     var registry = new RegistryBuilder(secretsManager).build();
 
     var invalidKey = "someInvalidSecretName" + UUID.randomUUID();

--- a/props-aws/src/intTest/java/sh/props/aws/AwsSecretsManagerIntTest.java
+++ b/props-aws/src/intTest/java/sh/props/aws/AwsSecretsManagerIntTest.java
@@ -33,10 +33,11 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static sh.props.aws.AwsSecretsManager.getSecretValue;
 
 import java.time.Duration;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -47,7 +48,6 @@ import sh.props.RegistryBuilder;
 import sh.props.converter.Cast;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerAsyncClient;
 import software.amazon.awssdk.services.secretsmanager.model.CreateSecretRequest;
-import software.amazon.awssdk.services.secretsmanager.model.CreateSecretResponse;
 import software.amazon.awssdk.services.secretsmanager.model.DeleteSecretRequest;
 
 @SuppressWarnings("NullAway")
@@ -58,8 +58,6 @@ class AwsSecretsManagerIntTest {
       format("secret1.%s.%s", System.nanoTime(), UUID.randomUUID());
   private static final String secret2 =
       format("secret2.%s.%s", System.nanoTime(), UUID.randomUUID());
-  private static CompletableFuture<CreateSecretResponse> putSecret1;
-  private static CompletableFuture<CreateSecretResponse> putSecret2;
   private static SecretsManagerAsyncClient client;
 
   @BeforeAll
@@ -67,36 +65,24 @@ class AwsSecretsManagerIntTest {
     // initialize the client
     client = AwsSecretsManager.buildClient(AwsSecretsManager.defaultClientConfiguration(), null);
 
-    // submit requests to asynchronously create secrets
-    putSecret1 =
-        client.createSecret(
-            CreateSecretRequest.builder().name(secret1).secretString(SECRET_VALUE).build());
-    putSecret2 =
-        client.createSecret(
-            CreateSecretRequest.builder().name(secret2).secretString(SECRET_VALUE).build());
+    // create secrets for the test env.
+    var key1 = CreateSecretRequest.builder().name(secret1).secretString(SECRET_VALUE).build();
+    client.createSecret(key1).join();
+
+    var key2 = CreateSecretRequest.builder().name(secret2).secretString(SECRET_VALUE).build();
+    client.createSecret(key2).join();
 
     Awaitility.setDefaultTimeout(5, SECONDS);
     Awaitility.setDefaultPollDelay(500, MILLISECONDS);
     Awaitility.setDefaultPollInterval(1, SECONDS);
-  }
-
-  /** Wait for the futures responsible for creating secrets for the test environment to complete. */
-  static void waitForSecretsToBeCreated() {
-    putSecret1.join();
-    putSecret2.join();
 
     // ensure the secrets can be retrieved and listed
     // the secrets don't immediately become available in AWS SecretsManager
     // and as such, we much first wait and ensure they are properly set-up by the test
-    await()
-        .until(
-            () -> AwsSecretsManager.getSecretValue(client, secret1).join().secretString(),
-            notNullValue());
+    await().until(() -> getSecretValue(client, secret1).join().secretString(), notNullValue());
     await()
         .pollDelay(Duration.ZERO)
-        .until(
-            () -> AwsSecretsManager.getSecretValue(client, secret2).join().secretString(),
-            notNullValue());
+        .until(() -> getSecretValue(client, secret2).join().secretString(), notNullValue());
     await().until(() -> AwsSecretsManager.listSecrets(client), hasSize(equalTo(2)));
   }
 
@@ -115,22 +101,18 @@ class AwsSecretsManagerIntTest {
   }
 
   @Test
-  @Timeout(value = 15)
+  @Timeout(value = 5)
   void secretsCanBeRetrievedFromSecretsManager() {
     // ARRANGE
-    waitForSecretsToBeCreated();
-
     var secretsManager = new AwsSecretsManager();
     var registry = new RegistryBuilder(secretsManager).build();
+
+    var invalidKey = "someInvalidSecretName" + UUID.randomUUID();
 
     // ACT
     CustomProp<String> prop1 = registry.builder(Cast.asString()).secret(true).build(secret1);
     CustomProp<String> prop2 = registry.builder(Cast.asString()).secret(true).build(secret2);
-    CustomProp<String> prop3 =
-        registry
-            .builder(Cast.asString())
-            .secret(true)
-            .build("someInvalidSecretName" + UUID.randomUUID());
+    CustomProp<String> prop3 = registry.builder(Cast.asString()).secret(true).build(invalidKey);
 
     // ASSERT
     await()
@@ -143,5 +125,28 @@ class AwsSecretsManagerIntTest {
         .until(prop2::get, equalTo(SECRET_VALUE));
 
     assertThat(prop3.get(), equalTo(null));
+  }
+
+  @Test
+  @Timeout(value = 5)
+  void loadSecretsOnDemand() {
+    // ARRANGE
+    var secretsManager = new AwsSecretsManager();
+    var registry = new RegistryBuilder(secretsManager).build();
+
+    var invalidKey = "someInvalidSecretName" + UUID.randomUUID();
+
+    // ACT
+    CustomProp<String> prop1 = registry.builder(Cast.asString()).secret(true).build(secret1);
+    String value2 = registry.get(secret2, Cast.asString());
+    String invalid = registry.get(invalidKey, Cast.asString());
+
+    // ASSERT
+    await()
+        .pollDelay(Duration.ZERO)
+        .pollInterval(Duration.ofNanos(100))
+        .until(prop1::get, equalTo(SECRET_VALUE));
+    assertThat(value2, equalTo(SECRET_VALUE));
+    assertThat(invalid, nullValue());
   }
 }

--- a/props-aws/src/main/java/sh/props/aws/AwsHelpers.java
+++ b/props-aws/src/main/java/sh/props/aws/AwsHelpers.java
@@ -1,0 +1,107 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2021 - 2021 Mihai Bojin
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+package sh.props.aws;
+
+import static java.util.stream.Collectors.toList;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import sh.props.annotations.Nullable;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.core.retry.RetryPolicy;
+import software.amazon.awssdk.core.retry.backoff.BackoffStrategy;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerAsyncClient;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueResponse;
+import software.amazon.awssdk.services.secretsmanager.model.ListSecretsResponse;
+import software.amazon.awssdk.services.secretsmanager.model.SecretListEntry;
+import software.amazon.awssdk.services.secretsmanager.model.SecretsManagerException;
+
+class AwsHelpers {
+  /**
+   * Default implementation for AWS's client configuration, that set a default timeout of 5 seconds
+   * and will retry calls failed due to throttling up to 5 times (see {@link
+   * BackoffStrategy#defaultThrottlingStrategy()}).
+   *
+   * @return a valid AWS configuration
+   */
+  static ClientOverrideConfiguration defaultClientConfiguration() {
+    return ClientOverrideConfiguration.builder()
+        .apiCallAttemptTimeout(Duration.ofSeconds(5))
+        .retryPolicy(
+            RetryPolicy.builder()
+                .backoffStrategy(BackoffStrategy.defaultThrottlingStrategy())
+                .numRetries(5)
+                .build())
+        .build();
+  }
+
+  /**
+   * Initializes a client.
+   *
+   * @param config the AWS client configuration
+   * @param region the region that the client should use; if null, the implementation will choose
+   * @return an initialized object
+   */
+  static SecretsManagerAsyncClient buildClient(
+      ClientOverrideConfiguration config, @Nullable Region region) {
+    var builder = SecretsManagerAsyncClient.builder().overrideConfiguration(config);
+    if (region != null) {
+      builder.region(region);
+    }
+    return builder.build();
+  }
+
+  /**
+   * Uses the provided client to retrieve a secret by its id.
+   *
+   * @param client the client which will execute the operation
+   * @param id the secret to retrieve
+   * @return a {@link CompletableFuture} that, when completed, will return the secret's value
+   */
+  static CompletableFuture<GetSecretValueResponse> getSecretValue(
+      SecretsManagerAsyncClient client, String id) {
+    return client.getSecretValue(GetSecretValueRequest.builder().secretId(id).build());
+  }
+
+  /**
+   * Retrieves a list of all the defined secrets. We need to wait for this operation to complete, as
+   * we need the list of secrets before retrieving their values.
+   *
+   * @param client the client which will execute the operation
+   * @return a list of defined secrets
+   * @throws SecretsManagerException if the operation fails
+   */
+  static List<String> listSecrets(SecretsManagerAsyncClient client) throws SecretsManagerException {
+    return client
+        .listSecrets()
+        .thenApply(ListSecretsResponse::secretList)
+        .thenApply(secrets -> secrets.stream().map(SecretListEntry::name).collect(toList()))
+        .join();
+  }
+}


### PR DESCRIPTION
# Why?

AWS SecretsManager as a source without eagerly loading all secrets.

Closes #63

# Checklist

Please ensure the following conditions are met:

[comment]: <> (- [ ] I have signed the [CLA]&#40;../CLA.md&#41; &#40;additional [details here]&#40;/contributors/README.md&#41;&#41;)

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
