### PR TITLE
Alias layers directly and avoid having to define source ID's in each implementation

### DIFF
--- a/props-aws/src/main/java/sh/props/aws/AwsSecretsManager.java
+++ b/props-aws/src/main/java/sh/props/aws/AwsSecretsManager.java
@@ -96,11 +96,6 @@ public class AwsSecretsManager extends Source {
   }
 
   @Override
-  public String id() {
-    return ID;
-  }
-
-  @Override
   public Map<String, String> get() {
     var definedSecrets = listSecrets(clients.get(0));
     retrieveSecrets(definedSecrets);

--- a/props-aws/src/main/java/sh/props/aws/AwsSecretsManager.java
+++ b/props-aws/src/main/java/sh/props/aws/AwsSecretsManager.java
@@ -88,16 +88,16 @@ public class AwsSecretsManager extends Source {
    * @param regions the AWS region (or regions) to use for retrieving values.
    */
   public AwsSecretsManager(ClientOverrideConfiguration configuration, String... regions) {
-    List<Region> regions1;
     if (regions == null || regions.length == 0) {
       // if no region is specified, use the default, as determined by AWS's implementation
-      regions1 = List.of();
       this.clients = List.of(buildClient(configuration, null));
     } else {
       // otherwise, create one client for each specified region
-      regions1 = Stream.of(regions).map(Region::of).collect(toList());
       this.clients =
-          regions1.stream().map(region -> buildClient(configuration, region)).collect(toList());
+          Stream.of(regions)
+              .map(Region::of)
+              .map(region -> buildClient(configuration, region))
+              .collect(toList());
     }
   }
 

--- a/props-aws/src/main/java/sh/props/aws/AwsSecretsManagerOnDemand.java
+++ b/props-aws/src/main/java/sh/props/aws/AwsSecretsManagerOnDemand.java
@@ -112,9 +112,4 @@ public class AwsSecretsManagerOnDemand extends OnDemandSource {
         .handle((response, err) -> AwsHelpers.processSecretResponse(response, err, key))
         .join();
   }
-
-  @Override
-  public String id() {
-    return ID;
-  }
 }

--- a/props-core/src/main/java/sh/props/CustomPropBuilder.java
+++ b/props-core/src/main/java/sh/props/CustomPropBuilder.java
@@ -25,6 +25,8 @@
 
 package sh.props;
 
+import static sh.props.Registry.assertNotNull;
+
 import sh.props.annotations.Nullable;
 import sh.props.converter.Converter;
 
@@ -49,14 +51,10 @@ public class CustomPropBuilder<T> {
    * @param converter the type converter that can serialize/deserialize the Prop's value
    */
   public CustomPropBuilder(Registry registry, Converter<T> converter) {
-    if (registry == null) {
-      throw new IllegalArgumentException("The registry cannot be null");
-    }
-    this.registry = registry;
+    assertNotNull(registry, "registry");
+    assertNotNull(converter, "converter");
 
-    if (converter == null) {
-      throw new IllegalArgumentException("The converter cannot be null");
-    }
+    this.registry = registry;
     this.converter = converter;
   }
 

--- a/props-core/src/main/java/sh/props/Datastore.java
+++ b/props-core/src/main/java/sh/props/Datastore.java
@@ -46,6 +46,17 @@ interface Datastore {
   Pair<String, Layer> get(String key);
 
   /**
+   * Retrieves a value for the specified key, from the specified layer.
+   *
+   * @param key the key to look for
+   * @param layer the layer to retrieve the value from
+   * @return a {@link Pair} containing the value and defining layer if found, or <code>null
+   *     </code>
+   */
+  @Nullable
+  Pair<String, Layer> get(String key, Layer layer);
+
+  /**
    * Updates a value and its originating layer, for the specified key.
    *
    * @param key the key to update

--- a/props-core/src/main/java/sh/props/Datastore.java
+++ b/props-core/src/main/java/sh/props/Datastore.java
@@ -46,17 +46,6 @@ interface Datastore {
   Pair<String, Layer> get(String key);
 
   /**
-   * Retrieves a value for the specified key, from the specified layer.
-   *
-   * @param key the key to look for
-   * @param layer the layer to retrieve the value from
-   * @return a {@link Pair} containing the value and defining layer if found, or <code>null
-   *     </code>
-   */
-  @Nullable
-  Pair<String, Layer> get(String key, Layer layer);
-
-  /**
    * Updates a value and its originating layer, for the specified key.
    *
    * @param key the key to update

--- a/props-core/src/main/java/sh/props/Layer.java
+++ b/props-core/src/main/java/sh/props/Layer.java
@@ -44,6 +44,7 @@ import sh.props.source.Source;
  */
 public class Layer implements Consumer<Map<String, String>>, LoadOnDemand {
 
+  protected final String alias;
   private final Source source;
   private final Registry registry;
   private final HashMap<String, String> store = new HashMap<>();
@@ -58,11 +59,14 @@ public class Layer implements Consumer<Map<String, String>>, LoadOnDemand {
    * Class constructor.
    *
    * @param source the source that provides data for this layer
+   * @param alias a unique reference that can identify the source in a {@link Registry}; if <code>
+   *     null</code> is provided, the implementation will use {@link Source#id()} as an alias
    * @param registry a reference to the associated registry
    * @param priority the priority of this layer
    */
-  protected Layer(Source source, Registry registry, int priority) {
+  protected Layer(Source source, @Nullable String alias, Registry registry, int priority) {
     this.source = source;
+    this.alias = alias != null ? alias : source.id();
     this.registry = registry;
     this.priority = priority;
 
@@ -86,10 +90,6 @@ public class Layer implements Consumer<Map<String, String>>, LoadOnDemand {
     this.source.refresh();
 
     return this;
-  }
-
-  public String id() {
-    return ""; // TODO(mihaibojin): complete this / take id in constructor
   }
 
   /**
@@ -212,8 +212,6 @@ public class Layer implements Consumer<Map<String, String>>, LoadOnDemand {
 
   @Override
   public String toString() {
-    return format(
-        "Layer(%s, id=%s, priority=%d)",
-        this.source.getClass().getSimpleName(), this.id(), this.priority);
+    return format("Layer(%s, alias=%s, priority=%d)", this.source.id(), this.alias, this.priority);
   }
 }

--- a/props-core/src/main/java/sh/props/Layer.java
+++ b/props-core/src/main/java/sh/props/Layer.java
@@ -30,22 +30,20 @@ import static java.lang.String.format;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
 import sh.props.annotations.Nullable;
-import sh.props.source.LoadOnDemand;
 import sh.props.source.Source;
 
 /**
  * Wraps a {@link Source} and holds the logic for prioritizing which Source will return the
  * effective value for each requested key.
  */
-public class Layer implements Consumer<Map<String, String>>, LoadOnDemand {
+public class Layer implements Consumer<Map<String, String>> {
 
   protected final String alias;
-  private final Source source;
+  final Source source;
   private final Registry registry;
   private final HashMap<String, String> store = new HashMap<>();
 
@@ -121,28 +119,6 @@ public class Layer implements Consumer<Map<String, String>>, LoadOnDemand {
   @Nullable
   public String get(String key) {
     return this.store.get(key);
-  }
-
-  /**
-   * Delegates to the underlying source's {@link Source#loadOnDemand()}.
-   *
-   * @return true if the {@link Source} can load values on-demand, false if it loads them in bulk.
-   */
-  @Override
-  public boolean loadOnDemand() {
-    return source.loadOnDemand();
-  }
-
-  /**
-   * Delegates to the underlying source's {@link Source#registerKey(String)}, notifying it that the
-   * specified key was bound by a {@link Registry}.
-   *
-   * @param key the key pointing to the Prop that was recently bound
-   * @return the underlying source's {@link CompletableFuture}
-   */
-  @Override
-  public CompletableFuture<String> registerKey(String key) {
-    return this.source.registerKey(key);
   }
 
   public int priority() {

--- a/props-core/src/main/java/sh/props/Layer.java
+++ b/props-core/src/main/java/sh/props/Layer.java
@@ -88,6 +88,10 @@ public class Layer implements Consumer<Map<String, String>>, LoadOnDemand {
     return this;
   }
 
+  public String id() {
+    return ""; // TODO(mihaibojin): complete this / take id in constructor
+  }
+
   /**
    * References the previous layer in logical order.
    *
@@ -106,15 +110,6 @@ public class Layer implements Consumer<Map<String, String>>, LoadOnDemand {
   @Nullable
   public Layer next() {
     return this.next;
-  }
-
-  /**
-   * Delegates to {@link Source#id()}.
-   *
-   * @return the id of the underlying source
-   */
-  public String id() {
-    return this.source.id();
   }
 
   /**
@@ -217,6 +212,8 @@ public class Layer implements Consumer<Map<String, String>>, LoadOnDemand {
 
   @Override
   public String toString() {
-    return format("Layer(id=%s, priority=%d)", this.id(), this.priority);
+    return format(
+        "Layer(%s, id=%s, priority=%d)",
+        this.source.getClass().getSimpleName(), this.id(), this.priority);
   }
 }

--- a/props-core/src/main/java/sh/props/Layer.java
+++ b/props-core/src/main/java/sh/props/Layer.java
@@ -156,9 +156,9 @@ public class Layer implements Consumer<Map<String, String>>, LoadOnDemand {
   @Override
   public void accept(Map<String, String> data) {
     // disallow more than one concurrent update from taking place
-    // TODO(mihaibojin): this has the potential to create a lot of contention, especially if using
-    //                   `OnDemandSource`s which rely on CompletableFutures to process updates, upon
-    //                   a new key registration (LoadOnDemand#registerKey)
+    // TODO(mihaibojin): this lock has the potential to create a lot of contention, especially if
+    //                   using `OnDemandSource`s which rely on CompletableFutures to process
+    //                   updates, upon a new key registration (LoadOnDemand#registerKey)
     this.lock.lock();
     try {
       // iterate over the current values

--- a/props-core/src/main/java/sh/props/Registry.java
+++ b/props-core/src/main/java/sh/props/Registry.java
@@ -212,6 +212,7 @@ public class Registry implements Notifiable {
    * @param alias the alias of the {@link sh.props.source.Source} from which the value should be
    *     retrieved; if <code>null</code> is passed {@link #get(String, Converter)} will be called
    *     instead
+   * @param <T> the type of the returned type
    * @return a {@link Pair} containing the value and defining layer if found, or <code>null
    *     </code>
    */

--- a/props-core/src/main/java/sh/props/Registry.java
+++ b/props-core/src/main/java/sh/props/Registry.java
@@ -194,8 +194,37 @@ public class Registry implements Notifiable {
     }
 
     // finds the value and owning layer
-    Pair<String, Layer> valueLayer = this.store.get(key);
+    var valueLayer = this.store.get(key);
+    return getFromValueLayer(valueLayer, converter);
+  }
 
+  /**
+   * Retrieves a value for the specified key, from the specified layer.
+   *
+   * @param key the key to look for
+   * @param converter the type converter used to cast the value to its appropriate type
+   * @param layer the layer to retrieve the value from
+   * @return a {@link Pair} containing the value and defining layer if found, or <code>null
+   *     </code>
+   */
+  @Nullable
+  public <T> T get(String key, Converter<T> converter, Layer layer) {
+    // TODO(mihaibojin): implement get from layer tests
+    var valueLayer = store.get(key, layer);
+    return getFromValueLayer(valueLayer, converter);
+  }
+
+  /**
+   * Returns the value, converted to the appropriate type, if a value exists in the specified layer.
+   *
+   * @param <T> the type of the returned type
+   * @param valueLayer the value,layer pair from which the value should be extracted
+   * @param converter the type converter used to cast the value to its appropriate type
+   * @return a value cast to the appropriate type, or null if not found
+   */
+  @Nullable
+  private <T> T getFromValueLayer(
+      @Nullable Pair<String, Layer> valueLayer, Converter<T> converter) {
     // no value found, the key does not exist in the registry
     // or the value is null
     if (valueLayer == null || valueLayer.first == null) {

--- a/props-core/src/main/java/sh/props/RegistryBuilder.java
+++ b/props-core/src/main/java/sh/props/RegistryBuilder.java
@@ -104,9 +104,10 @@ public class RegistryBuilder {
     List<Layer> layers = new ArrayList<>(this.sources.size());
     for (var pair : this.sources) {
       Source source = assertNotNull(pair.first, "source");
+      String alias = pair.second;
 
       // wrap each source in a layer
-      Layer layer = new Layer(source, pair.second, registry, priority--);
+      Layer layer = new Layer(source, alias, registry, priority--);
 
       // link the previous and current layer
       layer.next = next;

--- a/props-core/src/main/java/sh/props/RegistryBuilder.java
+++ b/props-core/src/main/java/sh/props/RegistryBuilder.java
@@ -25,6 +25,8 @@
 
 package sh.props;
 
+import static sh.props.Registry.assertNotNull;
+
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.List;
@@ -101,12 +103,10 @@ public class RegistryBuilder {
 
     List<Layer> layers = new ArrayList<>(this.sources.size());
     for (var pair : this.sources) {
-      if (pair.first == null) {
-        throw new NullPointerException("The source cannot be null");
-      }
+      Source source = assertNotNull(pair.first, "source");
 
       // wrap each source in a layer
-      Layer layer = new Layer(pair.first, pair.second, registry, priority--);
+      Layer layer = new Layer(source, pair.second, registry, priority--);
 
       // link the previous and current layer
       layer.next = next;

--- a/props-core/src/main/java/sh/props/RegistryBuilder.java
+++ b/props-core/src/main/java/sh/props/RegistryBuilder.java
@@ -30,14 +30,21 @@ import java.util.ArrayList;
 import java.util.List;
 import sh.props.annotations.Nullable;
 import sh.props.source.Source;
+import sh.props.tuples.Pair;
+import sh.props.tuples.Tuple;
 
 public class RegistryBuilder {
 
-  ArrayDeque<Source> sources = new ArrayDeque<>();
+  ArrayDeque<Pair<Source, String>> sources = new ArrayDeque<>();
 
   /**
    * Class constructor that accepts sources that the {@link Registry} will use for retrieving
    * values.
+   *
+   * <p>This is a shorthand for quickly creating a Registry in cases where the client code does not
+   * care about retrieving values directly from a Source, in a reproducible way (same alias in
+   * subsequent JVM runs). If the implementation does require that feature, it can use {@link
+   * #withSource(Source, String)} to also provide an alias for each source.
    *
    * @param sources the source or sources to add to the registry
    */
@@ -46,19 +53,33 @@ public class RegistryBuilder {
     if (sources != null) {
       // if any sources are specified, add them
       for (Source source : sources) {
-        this.sources.addFirst(source);
+        withSource(source);
       }
     }
+  }
+
+  /**
+   * Registers a source with the current registry, without specifying an alias.
+   *
+   * @param source the source to register
+   * @return this builder object (fluent interface)
+   */
+  public RegistryBuilder withSource(Source source) {
+    this.sources.addFirst(Tuple.of(source, null));
+    return this;
   }
 
   /**
    * Registers a source with the current registry.
    *
    * @param source the source to register
+   * @param alias a reference that can be used to retrieve values directly from this source; if
+   *     <code>null</code> is provided, it will result in the source being identified by its {@link
+   *     Source#id()}
    * @return this builder object (fluent interface)
    */
-  public RegistryBuilder withSource(Source source) {
-    this.sources.addFirst(source);
+  public RegistryBuilder withSource(Source source, @Nullable String alias) {
+    this.sources.addFirst(Tuple.of(source, alias));
     return this;
   }
 
@@ -79,9 +100,13 @@ public class RegistryBuilder {
     @Nullable Layer next = null;
 
     List<Layer> layers = new ArrayList<>(this.sources.size());
-    for (Source source : this.sources) {
+    for (var pair : this.sources) {
+      if (pair.first == null) {
+        throw new NullPointerException("The source cannot be null");
+      }
+
       // wrap each source in a layer
-      Layer layer = new Layer(source, registry, priority--);
+      Layer layer = new Layer(pair.first, pair.second, registry, priority--);
 
       // link the previous and current layer
       layer.next = next;

--- a/props-core/src/main/java/sh/props/SourceDeserializer.java
+++ b/props-core/src/main/java/sh/props/SourceDeserializer.java
@@ -27,6 +27,7 @@ package sh.props;
 
 import static java.lang.String.format;
 import static java.util.function.Predicate.not;
+import static sh.props.Registry.assertNotNull;
 
 import java.io.BufferedReader;
 import java.io.InputStream;
@@ -171,9 +172,7 @@ public class SourceDeserializer {
      * @return this builder object (fluent interface)
      */
     public <T extends Source> Builder withSource(String key, SourceFactory<T> factory) {
-      if (factory == null) {
-        throw new IllegalArgumentException("Cannot register a null source");
-      }
+      assertNotNull(factory, "source factory");
 
       // register the source class and ensure the operation succeeded
       var prev = deserializers.putIfAbsent(key.toLowerCase(), factory);

--- a/props-core/src/main/java/sh/props/SourceDeserializer.java
+++ b/props-core/src/main/java/sh/props/SourceDeserializer.java
@@ -162,7 +162,8 @@ public class SourceDeserializer {
 
     static {
       // define the core source implementations
-      MAP.put(ClasspathPropertyFile.ID, new ClasspathPropertyFile.Factory());
+      // TODO: define IDs
+      MAP.put("classpath", new ClasspathPropertyFile.Factory());
       MAP.put(Environment.ID, new Environment.Factory());
       MAP.put(PropertyFile.ID, new PropertyFile.Factory());
       MAP.put(SystemProperties.ID, new SystemProperties.Factory());

--- a/props-core/src/main/java/sh/props/SourceDeserializer.java
+++ b/props-core/src/main/java/sh/props/SourceDeserializer.java
@@ -123,8 +123,7 @@ public class SourceDeserializer {
     try (BufferedReader reader =
         new BufferedReader(new InputStreamReader(stream, Charset.defaultCharset()))) {
 
-      List<String> sourceConfig =
-          reader.lines().filter(not(String::isBlank)).collect(Collectors.toList());
+      var sourceConfig = reader.lines().filter(not(String::isBlank)).collect(Collectors.toList());
       return read(sourceConfig);
 
     } catch (Exception e) {
@@ -147,6 +146,11 @@ public class SourceDeserializer {
 
   /** Builder pattern for constructing {@link SourceDeserializer} objects. */
   public static class Builder {
+    public static final String CLASSPATH_SOURCE = "classpath";
+    public static final String ENV_SOURCE = "env";
+    public static final String FILE_SOURCE = "file";
+    public static final String SYSTEM_SOURCE = "system";
+
     final Map<String, SourceFactory<? extends Source>> deserializers = new HashMap<>();
 
     /**
@@ -155,10 +159,10 @@ public class SourceDeserializer {
      * @return this builder object (fluent interface)
      */
     public Builder withDefaults() {
-      deserializers.put("classpath", new ClasspathPropertyFile.Factory());
-      deserializers.put("env", new Environment.Factory());
-      deserializers.put("file", new PropertyFile.Factory());
-      deserializers.put("system", new SystemProperties.Factory());
+      deserializers.put(CLASSPATH_SOURCE, new ClasspathPropertyFile.Factory());
+      deserializers.put(ENV_SOURCE, new Environment.Factory());
+      deserializers.put(FILE_SOURCE, new PropertyFile.Factory());
+      deserializers.put(SYSTEM_SOURCE, new SystemProperties.Factory());
       return this;
     }
 

--- a/props-core/src/main/java/sh/props/SourceDeserializer.java
+++ b/props-core/src/main/java/sh/props/SourceDeserializer.java
@@ -32,6 +32,7 @@ import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.Charset;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -43,6 +44,8 @@ import sh.props.source.impl.ClasspathPropertyFile;
 import sh.props.source.impl.Environment;
 import sh.props.source.impl.PropertyFile;
 import sh.props.source.impl.SystemProperties;
+import sh.props.tuples.Pair;
+import sh.props.tuples.Tuple;
 
 /**
  * Allows reading and deserializing {@link Source} configuration from an input stream.
@@ -53,38 +56,69 @@ import sh.props.source.impl.SystemProperties;
  * appropriately parse it and construct the {@link Source}.
  */
 public class SourceDeserializer {
+  private final Map<String, SourceFactory<? extends Source>> deserializers;
 
   /**
-   * Allows external implementations to register additional sources, which will then be usable for
-   * deserialization from a configuration file.
+   * Class constructor that initializes the known deserializers.
    *
-   * @param key the key to register; must not have been previously bound
-   * @param factory the {@link Source} this key should be instantiated to
-   * @param <T> the type of the Source associated with the specified key
+   * @param deserializers the list of {@link SourceFactory} objects to register
    */
-  public static <T extends Source> void register(String key, SourceFactory<T> factory) {
-    if (factory == null) {
-      throw new IllegalArgumentException("Cannot register a null factory");
+  protected SourceDeserializer(Map<String, SourceFactory<? extends Source>> deserializers) {
+    this.deserializers = Collections.unmodifiableMap(deserializers);
+  }
+
+  /**
+   * Finds a potential {@link Source} identifier in the specified line.
+   *
+   * @param line the line to process
+   * @return an (id, options) pair
+   */
+  static Pair<String, String> processSourceConfig(String line) {
+    line = line.trim();
+    int pos = line.indexOf('=');
+    if (pos == -1) {
+      // the options part was not specified
+      return Tuple.of(line.toLowerCase(), null);
     }
 
-    // register the source class and ensure the operation succeeded
-    SourceFactory<? extends Source> prev = Holder.MAP.putIfAbsent(key.toLowerCase(), factory);
-    if (prev != null) {
-      throw new IllegalArgumentException(
-          key
-              + " cannot be overwritten; it was previously registered with "
-              + prev.getClass().getSimpleName());
+    // return the (id, options) pair
+    return Tuple.of(line.substring(0, pos).toLowerCase(), line.substring(pos + 1));
+  }
+
+  /**
+   * Helper method that attempts to construct a {@link Source} object by calling {@link
+   * SourceFactory#create(String)} through Java reflection.
+   *
+   * @param line the configuration line to process
+   * @return a constructed Source object
+   * @throws IllegalStateException if the configuration line cannot be used to identify an
+   *     appropriate source
+   */
+  @Nullable
+  Source constructSource(String line) {
+    // identify an implementation that can process this config line
+    Pair<String, String> config = processSourceConfig(line);
+    var factory = this.deserializers.get(config.first);
+    if (factory == null) {
+      // fail if the configuration file contains other artifacts
+      // this is to prevent users making wrong assumptions about their registry configuration
+      // e.g., assuming a key configuration file is there, when in fact it isn't
+      throw new IllegalStateException(
+          format("The specified config (%s) could not be mapped to a Source", line));
     }
+
+    // construct a Source by parsing the specified line
+    return factory.create(config.second);
   }
 
   /**
    * Reads {@link Source} configuration from the specified input stream and return an array of
-   * sources, which can be passed to {@link sh.props.RegistryBuilder#RegistryBuilder(Source...)}.
+   * sources, which can be passed to {@link RegistryBuilder#RegistryBuilder(Source...)}.
    *
    * @param stream the input stream representing the configuration data
    * @return an array of Source objects
    */
-  public static Source[] read(InputStream stream) {
+  public Source[] read(InputStream stream) {
     try (BufferedReader reader =
         new BufferedReader(new InputStreamReader(stream, Charset.defaultCharset()))) {
 
@@ -99,74 +133,64 @@ public class SourceDeserializer {
 
   /**
    * Reads {@link Source} configuration from the specified input stream and return an array of
-   * sources, which can be passed to {@link sh.props.RegistryBuilder#RegistryBuilder(Source...)}.
+   * sources, which can be passed to {@link RegistryBuilder#RegistryBuilder(Source...)}.
    *
    * @param sourceConfig a list of source configurations
    * @return an array of Source objects
    * @throws IllegalStateException if the configuration line cannot be used to identify an *
    *     appropriate source
    */
-  public static Source[] read(List<String> sourceConfig) {
-    return sourceConfig.stream().map(SourceDeserializer::constructSource).toArray(Source[]::new);
+  public Source[] read(List<String> sourceConfig) {
+    return sourceConfig.stream().map(this::constructSource).toArray(Source[]::new);
   }
 
-  /**
-   * Helper method that attempts to construct a {@link Source} object by calling {@link
-   * SourceFactory#create(String)} through Java reflection.
-   *
-   * @param line the configuration line to process
-   * @return a constructed Source object
-   * @throws IllegalStateException if the configuration line cannot be used to identify an
-   *     appropriate source
-   */
-  @Nullable
-  static Source constructSource(String line) {
-    // identify an implementation that can process this config line
-    String id = findId(line).toLowerCase();
-    SourceFactory<? extends Source> factory = Holder.MAP.get(id);
-    if (factory == null) {
-      // fail if the configuration file contains other artifacts
-      // this is to prevent users making wrong assumptions about their registry configuration
-      // e.g., assuming a key configuration file is there, when in fact it isn't
-      throw new IllegalStateException(
-          format(
-              "The specified config (%s) could not be mapped to a Source. Will not add to configuration.",
-              id));
+  /** Builder pattern for constructing {@link SourceDeserializer} objects. */
+  public static class Builder {
+    final Map<String, SourceFactory<? extends Source>> deserializers = new HashMap<>();
+
+    /**
+     * Registers the default {@link SourceFactory} objects provided by props-core.
+     *
+     * @return this builder object (fluent interface)
+     */
+    public Builder withDefaults() {
+      deserializers.put("classpath", new ClasspathPropertyFile.Factory());
+      deserializers.put("env", new Environment.Factory());
+      deserializers.put("file", new PropertyFile.Factory());
+      deserializers.put("system", new SystemProperties.Factory());
+      return this;
     }
 
-    // construct a Source by parsing the specified line
-    return factory.create(line);
-  }
+    /**
+     * Allows external implementations to register additional sources, which will then be usable for
+     * deserialization from a configuration file.
+     *
+     * @param key the key to register; must not have been previously bound
+     * @param factory the {@link Source} this key should be instantiated to
+     * @param <T> the type of the Source associated with the specified key
+     * @return this builder object (fluent interface)
+     */
+    public <T extends Source> Builder withSource(String key, SourceFactory<T> factory) {
+      if (factory == null) {
+        throw new IllegalArgumentException("Cannot register a null source");
+      }
 
-  /**
-   * Finds a potential {@link Source} identifier in the specified line.
-   *
-   * @param line the line to process
-   * @return the potential id
-   */
-  static String findId(String line) {
-    line = line.trim();
-    int pos = line.indexOf('=');
-    if (pos == -1) {
-      // return the line, as-is, since it doesn't contain any separators
-      return line;
+      // register the source class and ensure the operation succeeded
+      var prev = deserializers.putIfAbsent(key.toLowerCase(), factory);
+      if (prev != null) {
+        throw new IllegalArgumentException(
+            key.toLowerCase() + " is already registered for " + prev.getClass().getSimpleName());
+      }
+      return this;
     }
 
-    // return only the identifier
-    return line.substring(0, pos);
-  }
-
-  /** Static holder, ensuring the map does not get initialized if this feature is not used. */
-  private static class Holder {
-    public static final Map<String, SourceFactory<? extends Source>> MAP = new HashMap<>();
-
-    static {
-      // define the core source implementations
-      // TODO: define IDs
-      MAP.put("classpath", new ClasspathPropertyFile.Factory());
-      MAP.put(Environment.ID, new Environment.Factory());
-      MAP.put(PropertyFile.ID, new PropertyFile.Factory());
-      MAP.put(SystemProperties.ID, new SystemProperties.Factory());
+    /**
+     * Builds the source deserializer.
+     *
+     * @return an initialized {@link SourceDeserializer}
+     */
+    public SourceDeserializer build() {
+      return new SourceDeserializer(deserializers);
     }
   }
 }

--- a/props-core/src/main/java/sh/props/SyncStore.java
+++ b/props-core/src/main/java/sh/props/SyncStore.java
@@ -106,7 +106,7 @@ class SyncStore implements Datastore {
 
     SyncStore.assertLayerIsValid(search, vl);
 
-    if (Objects.equals(search.id(), l.id())) {
+    if (Objects.equals(search.alias, l.alias)) {
       // we're searching for this key's owner
       return vl;
     }

--- a/props-core/src/main/java/sh/props/SyncStore.java
+++ b/props-core/src/main/java/sh/props/SyncStore.java
@@ -25,6 +25,8 @@
 
 package sh.props;
 
+import static sh.props.Registry.assertNotNull;
+
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import sh.props.annotations.Nullable;
@@ -56,7 +58,7 @@ class SyncStore implements Datastore {
    */
   @Nullable
   private static Pair<String, Layer> findNextPotentialOwner(String key, Pair<String, Layer> vl) {
-    Layer l = nonNullLayer(vl.second);
+    Layer l = assertNotNull(vl.second, "layer");
 
     // search all layers with lower priority for the key
     while (l.prev() != null) {
@@ -69,19 +71,6 @@ class SyncStore implements Datastore {
 
     // if no layer defines this key
     return null;
-  }
-
-  /**
-   * Convenience method to check the correctness of the specified layer object.
-   *
-   * @param layer a reference that could be null
-   * @return a non-null reference
-   */
-  private static Layer nonNullLayer(@Nullable Layer layer) {
-    if (layer == null) {
-      throw new NullPointerException("Invalid state, layer should not be null!");
-    }
-    return layer;
   }
 
   /**
@@ -145,7 +134,7 @@ class SyncStore implements Datastore {
           // if we already defined a mapping for this key
 
           // first check the attempted mapping's priority
-          int oldPriority = nonNullLayer(current.second).priority();
+          int oldPriority = assertNotNull(current.second, "layer").priority();
           int priority = layer.priority();
           // if the layer's priority is lower than the current owner
           if (priority < oldPriority) {

--- a/props-core/src/main/java/sh/props/SyncStore.java
+++ b/props-core/src/main/java/sh/props/SyncStore.java
@@ -171,6 +171,7 @@ class SyncStore implements Datastore {
    * @return a {@link Pair} containing the value and defining layer if found, or <code>null
    *     </code>
    */
+  @Override
   @Nullable
   public Pair<String, Layer> get(String key, Layer layer) {
     Pair<String, Layer> effective = this.effectiveValues.get(key);

--- a/props-core/src/main/java/sh/props/source/Source.java
+++ b/props-core/src/main/java/sh/props/source/Source.java
@@ -123,7 +123,8 @@ public abstract class Source implements Supplier<Map<String, String>>, Subscriba
    *     sh.props.Registry}, allowing users to retrieve a value directly from a source
    */
   public final String id() {
-    return format("%s@%s", this.getClass().getSimpleName(), System.identityHashCode(this));
+    var hex = Integer.toHexString(System.identityHashCode(this));
+    return format("%s@%s", this.getClass().getSimpleName(), hex);
   }
 
   @Override

--- a/props-core/src/main/java/sh/props/source/Source.java
+++ b/props-core/src/main/java/sh/props/source/Source.java
@@ -39,6 +39,8 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import sh.props.Layer;
+import sh.props.converter.Converter;
 
 /**
  * Abstract class that permits subscribers to register for updates.
@@ -108,6 +110,28 @@ public abstract class Source implements Supplier<Map<String, String>>, Subscriba
   }
 
   /**
+   * Provides a unique reference for each Source implementation. By default, this method returns the
+   * implementation's name and a unique hash code computed at runtime. This method can help users
+   * reference a source in {@link sh.props.Registry#get(String, Converter, String)}.
+   *
+   * <p>This method is final and cannot be overwritten since that would create potential for
+   * confusion. When a user desired to reference sources by a deterministic identifier (reproducible
+   * in subsequent JVM runs), they should alias {@link Layer}s via {@link
+   * sh.props.RegistryBuilder#withSource(Source, String)}.
+   *
+   * @return a unique reference that's meant to enable client code to identify sources in a {@link
+   *     sh.props.Registry}, allowing users to retrieve a value directly from a source
+   */
+  public final String id() {
+    return format("%s@%s", this.getClass().getSimpleName(), System.identityHashCode(this));
+  }
+
+  @Override
+  public String toString() {
+    return format("Source(%s)", id());
+  }
+
+  /**
    * Sends the provided <code>data</code> to the wrapping layer.
    *
    * @param data the data to send to the Layer
@@ -116,10 +140,5 @@ public abstract class Source implements Supplier<Map<String, String>>, Subscriba
     for (Consumer<Map<String, String>> subscriber : this.layers) {
       subscriber.accept(data);
     }
-  }
-
-  @Override
-  public String toString() {
-    return format("Source(%s)", this.getClass().getSimpleName());
   }
 }

--- a/props-core/src/main/java/sh/props/source/Source.java
+++ b/props-core/src/main/java/sh/props/source/Source.java
@@ -84,13 +84,6 @@ public abstract class Source implements Supplier<Map<String, String>>, Subscriba
   }
 
   /**
-   * An unique identifier representing this source in the {@link sh.props.Registry}.
-   *
-   * @return an unique id
-   */
-  public abstract String id();
-
-  /**
    * Reads all known (key,value) pairs from the source.
    *
    * @return an updated {@link Map} containing all known key,value pairs
@@ -127,6 +120,6 @@ public abstract class Source implements Supplier<Map<String, String>>, Subscriba
 
   @Override
   public String toString() {
-    return format("Source(%s)", this.id());
+    return format("Source(%s)", this.getClass().getSimpleName());
   }
 }

--- a/props-core/src/main/java/sh/props/source/SourceFactory.java
+++ b/props-core/src/main/java/sh/props/source/SourceFactory.java
@@ -25,6 +25,8 @@
 
 package sh.props.source;
 
+import sh.props.annotations.Nullable;
+
 /**
  * Interface for {@link Source} factories.
  *
@@ -35,8 +37,8 @@ public interface SourceFactory<T extends Source> {
   /**
    * Constructs a {@link Source} object from the specified id.
    *
-   * @param id the identifier representing this source
+   * @param id the identifier representing this source; null if not needed
    * @return a constructed Source object
    */
-  T create(String id);
+  T create(@Nullable String id);
 }

--- a/props-core/src/main/java/sh/props/source/SourceFactory.java
+++ b/props-core/src/main/java/sh/props/source/SourceFactory.java
@@ -35,10 +35,10 @@ import sh.props.annotations.Nullable;
 @FunctionalInterface
 public interface SourceFactory<T extends Source> {
   /**
-   * Constructs a {@link Source} object from the specified id.
+   * Constructs a {@link Source} object, using the specified options.
    *
-   * @param id the identifier representing this source; null if not needed
+   * @param options configuration for the constructed source; null if not needed
    * @return a constructed Source object
    */
-  T create(@Nullable String id);
+  T create(@Nullable String options);
 }

--- a/props-core/src/main/java/sh/props/source/impl/ClasspathPropertyFile.java
+++ b/props-core/src/main/java/sh/props/source/impl/ClasspathPropertyFile.java
@@ -82,6 +82,7 @@ public class ClasspathPropertyFile extends Source {
      */
     @Override
     public ClasspathPropertyFile create(@Nullable String location) {
+      // TODO: assertNotNull(location, "location");
       if (location == null) {
         throw new IllegalArgumentException("Location cannot be null");
       }

--- a/props-core/src/main/java/sh/props/source/impl/ClasspathPropertyFile.java
+++ b/props-core/src/main/java/sh/props/source/impl/ClasspathPropertyFile.java
@@ -33,12 +33,12 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import sh.props.annotations.Nullable;
 import sh.props.source.Source;
 import sh.props.source.SourceFactory;
 
 /** Retrieves properties from a Java properties file, located on the classpath. */
 public class ClasspathPropertyFile extends Source {
-  public static final String ID = "classpath";
   private static final Logger log = Logger.getLogger(ClasspathPropertyFile.class.getName());
   private final String location;
 
@@ -77,18 +77,16 @@ public class ClasspathPropertyFile extends Source {
     /**
      * Initializes a {@link ClasspathPropertyFile} object from the specified id.
      *
-     * @param id the identifier representing this source
+     * @param location the location of the file on the classpath
      * @return a constructed Source object
      */
     @Override
-    public ClasspathPropertyFile create(String id) {
-      @SuppressWarnings("StringSplitter")
-      String[] parts = id.split("=");
-      if (parts.length != 2 || !ClasspathPropertyFile.ID.equals(parts[0])) {
-        throw new IllegalArgumentException("Invalid id '" + id + "' for the current class " + this);
+    public ClasspathPropertyFile create(@Nullable String location) {
+      if (location == null) {
+        throw new IllegalArgumentException("Location cannot be null");
       }
 
-      return new ClasspathPropertyFile(parts[1]);
+      return new ClasspathPropertyFile(location);
     }
   }
 }

--- a/props-core/src/main/java/sh/props/source/impl/ClasspathPropertyFile.java
+++ b/props-core/src/main/java/sh/props/source/impl/ClasspathPropertyFile.java
@@ -52,11 +52,6 @@ public class ClasspathPropertyFile extends Source {
   }
 
   @Override
-  public String id() {
-    return ID + "://" + this.location;
-  }
-
-  @Override
   public Map<String, String> get() {
     try (InputStream stream = this.getClass().getResourceAsStream(this.location)) {
       if (stream != null) {

--- a/props-core/src/main/java/sh/props/source/impl/Environment.java
+++ b/props-core/src/main/java/sh/props/source/impl/Environment.java
@@ -26,12 +26,12 @@
 package sh.props.source.impl;
 
 import java.util.Map;
+import sh.props.annotations.Nullable;
 import sh.props.source.Source;
 import sh.props.source.SourceFactory;
 
 /** Retrieves all environment variables. */
 public class Environment extends Source {
-  public static final String ID = "env";
 
   /**
    * Retrieves all environment variables.
@@ -45,18 +45,15 @@ public class Environment extends Source {
 
   /** Factory implementation. */
   public static class Factory implements SourceFactory<Environment> {
+
     /**
-     * Initializes an {@link Environment} object from the specified id.
+     * Initializes an {@link Environment} source.
      *
-     * @param id the identifier representing this source
+     * @param ignored unused for this source
      * @return a constructed Source object
      */
     @Override
-    public Environment create(String id) {
-      if (!Environment.ID.equals(id)) {
-        throw new IllegalArgumentException("Invalid id '" + id + "' for the current class " + this);
-      }
-
+    public Environment create(@Nullable String ignored) {
       return new Environment();
     }
   }

--- a/props-core/src/main/java/sh/props/source/impl/Environment.java
+++ b/props-core/src/main/java/sh/props/source/impl/Environment.java
@@ -34,16 +34,6 @@ public class Environment extends Source {
   public static final String ID = "env";
 
   /**
-   * An unique identifier representing this source in the {@link sh.props.Registry}.
-   *
-   * @return an unique id
-   */
-  @Override
-  public String id() {
-    return ID;
-  }
-
-  /**
    * Retrieves all environment variables.
    *
    * @return a map containing all env. variables

--- a/props-core/src/main/java/sh/props/source/impl/InMemory.java
+++ b/props-core/src/main/java/sh/props/source/impl/InMemory.java
@@ -60,11 +60,6 @@ public class InMemory extends Source {
     this.updateOnEveryWrite = updateOnEveryWrite;
   }
 
-  @Override
-  public String id() {
-    return ID;
-  }
-
   /**
    * Retrieves an unmodifiable map containing all (key,value) pairs defined in the {@link #store}.
    *

--- a/props-core/src/main/java/sh/props/source/impl/InMemory.java
+++ b/props-core/src/main/java/sh/props/source/impl/InMemory.java
@@ -35,7 +35,6 @@ import sh.props.source.Source;
 public class InMemory extends Source {
   public static final boolean UPDATE_REGISTRY_ON_EVERY_WRITE = true;
   public static final boolean UPDATE_REGISTRY_MANUALLY = false;
-  public static final String ID = "memory";
 
   private final ConcurrentHashMap<String, String> store = new ConcurrentHashMap<>();
 

--- a/props-core/src/main/java/sh/props/source/impl/PropertyFile.java
+++ b/props-core/src/main/java/sh/props/source/impl/PropertyFile.java
@@ -93,6 +93,7 @@ public class PropertyFile extends Source implements FileWatchable {
      */
     @Override
     public PropertyFile create(@Nullable String location) {
+      // TODO: assertNotNull(location, "location");
       if (location == null) {
         throw new IllegalArgumentException("Location cannot be null");
       }

--- a/props-core/src/main/java/sh/props/source/impl/PropertyFile.java
+++ b/props-core/src/main/java/sh/props/source/impl/PropertyFile.java
@@ -36,14 +36,13 @@ import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.Map;
 import java.util.logging.Logger;
+import sh.props.annotations.Nullable;
 import sh.props.source.FileWatchable;
 import sh.props.source.Source;
 import sh.props.source.SourceFactory;
 
 /** Retrieves properties from a Java properties file, located on disk. */
 public class PropertyFile extends Source implements FileWatchable {
-  public static final String ID = "file";
-
   private static final Logger log = Logger.getLogger(PropertyFile.class.getName());
   private final Path location;
 
@@ -89,18 +88,16 @@ public class PropertyFile extends Source implements FileWatchable {
     /**
      * Initializes a {@link PropertyFile} object from the specified id.
      *
-     * @param id the identifier representing this source
+     * @param location the location of the file on disk
      * @return a constructed Source object
      */
     @Override
-    public PropertyFile create(String id) {
-      @SuppressWarnings("StringSplitter")
-      String[] parts = id.split("=");
-      if (parts.length != 2 || !PropertyFile.ID.equals(parts[0])) {
-        throw new IllegalArgumentException("Invalid id '" + id + "' for the current class " + this);
+    public PropertyFile create(@Nullable String location) {
+      if (location == null) {
+        throw new IllegalArgumentException("Location cannot be null");
       }
 
-      return new PropertyFile(Paths.get(parts[1]));
+      return new PropertyFile(Paths.get(location));
     }
   }
 }

--- a/props-core/src/main/java/sh/props/source/impl/PropertyFile.java
+++ b/props-core/src/main/java/sh/props/source/impl/PropertyFile.java
@@ -74,16 +74,6 @@ public class PropertyFile extends Source implements FileWatchable {
   }
 
   /**
-   * Returns an unique identifier designating this property file.
-   *
-   * @return an unique id pointing to the property file on disk
-   */
-  @Override
-  public String id() {
-    return ID + "://" + this.location.toString();
-  }
-
-  /**
    * The location of the property file backing this source.
    *
    * @return a valid path to the backing file, on disk

--- a/props-core/src/main/java/sh/props/source/impl/SystemProperties.java
+++ b/props-core/src/main/java/sh/props/source/impl/SystemProperties.java
@@ -26,13 +26,12 @@
 package sh.props.source.impl;
 
 import java.util.Map;
+import sh.props.annotations.Nullable;
 import sh.props.source.Source;
 import sh.props.source.SourceFactory;
 
 /** Retrieves system properties. */
 public class SystemProperties extends Source {
-  public static final String ID = "system";
-
   /**
    * Retrieves all system properties.
    *
@@ -47,17 +46,13 @@ public class SystemProperties extends Source {
   public static class Factory implements SourceFactory<SystemProperties> {
 
     /**
-     * Initializes a {@link SystemProperties} object from the specified id.
+     * Initializes a {@link SystemProperties} object.
      *
-     * @param id the identifier representing this source
+     * @param ignored unused for this source
      * @return a constructed Source object
      */
     @Override
-    public SystemProperties create(String id) {
-      if (!SystemProperties.ID.equals(id)) {
-        throw new IllegalArgumentException("Invalid id '" + id + "' for the current class " + this);
-      }
-
+    public SystemProperties create(@Nullable String ignored) {
       return new SystemProperties();
     }
   }

--- a/props-core/src/main/java/sh/props/source/impl/SystemProperties.java
+++ b/props-core/src/main/java/sh/props/source/impl/SystemProperties.java
@@ -33,11 +33,6 @@ import sh.props.source.SourceFactory;
 public class SystemProperties extends Source {
   public static final String ID = "system";
 
-  @Override
-  public String id() {
-    return ID;
-  }
-
   /**
    * Retrieves all system properties.
    *

--- a/props-core/src/main/java/sh/props/source/refresh/FileWatchSvc.java
+++ b/props-core/src/main/java/sh/props/source/refresh/FileWatchSvc.java
@@ -101,6 +101,8 @@ public class FileWatchSvc implements Runnable {
    */
   public <T extends Source & FileWatchable> void refreshOnChanges(T source) throws IOException {
     Path path = source.file();
+    // TODO: assertNotNull(source, "source");
+    // TODO: assertNotNull(path, "source file");
     if (path == null) {
       throw new NullPointerException("The passed argument must not be null");
     }

--- a/props-core/src/test/java/sh/props/SourceDeserializerTest.java
+++ b/props-core/src/test/java/sh/props/SourceDeserializerTest.java
@@ -192,7 +192,7 @@ class SourceDeserializerTest {
     var deserializer =
         new SourceDeserializer.Builder()
             .withDefaults()
-            .withSource(TestSource.ID, new TestSource.Factory())
+            .withSource("test-source", new TestSource.Factory())
             .build();
 
     Source[] sources =

--- a/props-core/src/test/java/sh/props/SourceDeserializerTest.java
+++ b/props-core/src/test/java/sh/props/SourceDeserializerTest.java
@@ -74,7 +74,8 @@ class SourceDeserializerTest {
     TestFileUtil.appendLine("file=" + propFile, configFile);
 
     // store the sources to be used by each test
-    sources = SourceDeserializer.read(Files.newInputStream(configFile));
+    var deserializer = new SourceDeserializer.Builder().withDefaults().build();
+    sources = deserializer.read(Files.newInputStream(configFile));
   }
 
   @Test
@@ -155,8 +156,9 @@ class SourceDeserializerTest {
   @Test
   void readFromConfigList() {
     // ARRANGE
+    var deserializer = new SourceDeserializer.Builder().withDefaults().build();
     Source[] sources =
-        SourceDeserializer.read(
+        deserializer.read(
             List.of("classpath=/source/standard-types.properties", "file=" + propFile));
 
     // ACT
@@ -175,21 +177,26 @@ class SourceDeserializerTest {
 
   @Test
   void cannotDeserializeWithUnknownSource() {
+    // ARRANGE
+    var deserializer = new SourceDeserializer.Builder().withDefaults().build();
+
+    // ACT / ASSERT
     assertThrows(
         IllegalStateException.class,
-        () ->
-            SourceDeserializer.read(
-                List.of("classpath=/source/standard-types.properties", "UNKNOWN")));
+        () -> deserializer.read(List.of("classpath=/source/standard-types.properties", "UNKNOWN")));
   }
 
   @Test
   void customSourceImplementation() {
     // ARRANGE
-    SourceDeserializer.register(TestSource.ID, new TestSource.Factory());
+    var deserializer =
+        new SourceDeserializer.Builder()
+            .withDefaults()
+            .withSource(TestSource.ID, new TestSource.Factory())
+            .build();
 
     Source[] sources =
-        SourceDeserializer.read(
-            List.of("classpath=/source/standard-types.properties", "test-source"));
+        deserializer.read(List.of("classpath=/source/standard-types.properties", "test-source"));
 
     // ACT
     Registry registry = new RegistryBuilder(sources).build();

--- a/props-core/src/testFixtures/java/sh/props/textfixtures/TestOnDemandSource.java
+++ b/props-core/src/testFixtures/java/sh/props/textfixtures/TestOnDemandSource.java
@@ -53,9 +53,4 @@ public class TestOnDemandSource extends OnDemandSource {
     // retrieve the key
     return backingData.get(key);
   }
-
-  @Override
-  public String id() {
-    return "ON_DEMAND";
-  }
 }

--- a/props-core/src/testFixtures/java/sh/props/textfixtures/TestSource.java
+++ b/props-core/src/testFixtures/java/sh/props/textfixtures/TestSource.java
@@ -26,7 +26,7 @@
 package sh.props.textfixtures;
 
 import java.util.Map;
-import java.util.Objects;
+import sh.props.annotations.Nullable;
 import sh.props.source.Source;
 import sh.props.source.SourceFactory;
 
@@ -43,11 +43,7 @@ public class TestSource extends Source {
   public static class Factory implements SourceFactory<TestSource> {
 
     @Override
-    public TestSource create(String id) {
-      if (!Objects.equals(TestSource.ID, id)) {
-        throw new IllegalArgumentException("Invalid id: " + id);
-      }
-
+    public TestSource create(@Nullable String ignored) {
       return new TestSource();
     }
   }

--- a/props-core/src/testFixtures/java/sh/props/textfixtures/TestSource.java
+++ b/props-core/src/testFixtures/java/sh/props/textfixtures/TestSource.java
@@ -35,11 +35,6 @@ public class TestSource extends Source {
   public static final String ID = "test-source";
 
   @Override
-  public String id() {
-    return "test-source";
-  }
-
-  @Override
   public Map<String, String> get() {
     return Map.of("key", "value");
   }

--- a/props-core/src/testFixtures/java/sh/props/textfixtures/TestSource.java
+++ b/props-core/src/testFixtures/java/sh/props/textfixtures/TestSource.java
@@ -32,7 +32,6 @@ import sh.props.source.SourceFactory;
 
 /** Creates a source used for tests, which only defines a key=value entry. */
 public class TestSource extends Source {
-  public static final String ID = "test-source";
 
   @Override
   public Map<String, String> get() {

--- a/props-mongodb/src/main/java/sh/props/mongodb/MongoDbStore.java
+++ b/props-mongodb/src/main/java/sh/props/mongodb/MongoDbStore.java
@@ -231,11 +231,6 @@ public class MongoDbStore extends Source {
     return Collections.unmodifiableMap(results);
   }
 
-  @Override
-  public String id() {
-    return ID;
-  }
-
   /**
    * Retrieves all the key,value pairs defined in the underlying collection.
    *


### PR DESCRIPTION
# Why
- simplified the contract for sources
- defined aliases at Layer level
- closes #65

# Checklist

Please ensure the following conditions are met:

[comment]: <> (- [ ] I have signed the [CLA]&#40;../CLA.md&#41; &#40;additional [details here]&#40;/contributors/README.md&#41;&#41;)

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)

Thank you!